### PR TITLE
* Added alternative example of RabiGenerator.

### DIFF
--- a/qiskit/ignis/experiments/base/generator.py
+++ b/qiskit/ignis/experiments/base/generator.py
@@ -40,7 +40,7 @@ class Generator(ABC):
             self._qubits = list(range(self._num_qubits))
         else:
             self._qubits = list(qubits)
-            self._num_qubits = max(self._qubits)+1
+            self._num_qubits = len(self._qubits)
 
     @property
     def name(self) -> str:

--- a/qiskit/ignis/experiments/base/generator.py
+++ b/qiskit/ignis/experiments/base/generator.py
@@ -40,7 +40,7 @@ class Generator(ABC):
             self._qubits = list(range(self._num_qubits))
         else:
             self._qubits = list(qubits)
-            self._num_qubits = len(self._qubits)
+            self._num_qubits = max(self._qubits)+1
 
     @property
     def name(self) -> str:

--- a/qiskit/ignis/experiments/calibration/methods/basic_1q.py
+++ b/qiskit/ignis/experiments/calibration/methods/basic_1q.py
@@ -228,9 +228,9 @@ class SinglePulseSingleParameterGenerator(Generator):
         # Frequency shift and phase shift are not part of a pulse.
         params = {}
         for key, value in self.parameters.items():
-            if key not in ['freq_shift', 'phase_shift']:
+            if key not in ['frequency', 'phase']:
                 params[key] = value
-        
+
         if self._pulse is None:
             sched += sched.insert(0, Play(Gaussian(**params), ch))
         else:


### PR DESCRIPTION
### Summary
Alternative design proposal for Generators.

### Details and comments
This shows that we do not need a `BaseCalibrationGenerator`. The implementation is a bit less flexible but easier to read and maintain.


