### PR TITLE
Workflow and general refactoring

### DIFF
--- a/qiskit/ignis/experiments/calibration/__init__.py
+++ b/qiskit/ignis/experiments/calibration/__init__.py
@@ -12,4 +12,6 @@
 
 """Qiskit Ignis calibration module."""
 
-from .cal_base_analysis import Calibration1DAnalysis
+from qiskit.ignis.experiments.calibration.analysis.cal_1d_analysis import Calibration1DAnalysis
+from qiskit.ignis.experiments.calibration.cal_table import PulseTable
+from qiskit.ignis.experiments.calibration.mock import FakeSingleQubitTable

--- a/qiskit/ignis/experiments/calibration/__init__.py
+++ b/qiskit/ignis/experiments/calibration/__init__.py
@@ -10,7 +10,15 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""Qiskit Ignis calibration module."""
+"""
+Qiskit Ignis calibration module.
+
+Calibration1DAnalysis analyzes experiments in which one parameter is scanned.
+The values of this parameter form the x_values. The experiment may have several
+series which are interpreted as different curves. The x_values metadata for
+each circuit should therefore be a dict with one entry and have the form
+{parameter_name: parameter_value}.
+"""
 
 from qiskit.ignis.experiments.calibration.analysis.cal_1d_analysis import Calibration1DAnalysis
 from qiskit.ignis.experiments.calibration.cal_table import PulseTable

--- a/qiskit/ignis/experiments/calibration/__init__.py
+++ b/qiskit/ignis/experiments/calibration/__init__.py
@@ -13,6 +13,13 @@
 """
 Qiskit Ignis calibration module.
 
+Typically, we calibrate pulse parameters. These pulse parameters are
+stored in a table with their values. The calibration experiments
+rely on generators to produce the circuits and analyze the data
+with an Analysis class, typically responsible for extracting pulse
+parameters from the data. The analysis defines the steps by which
+the data is processed.
+
 Calibration1DAnalysis analyzes experiments in which one parameter is scanned.
 The values of this parameter form the x_values. The experiment may have several
 series which are interpreted as different curves. The x_values metadata for

--- a/qiskit/ignis/experiments/calibration/analysis/cal_1d_analysis.py
+++ b/qiskit/ignis/experiments/calibration/analysis/cal_1d_analysis.py
@@ -13,7 +13,7 @@
 """Qiskit Ignis calibration module."""
 
 from collections import defaultdict
-from typing import Union, Dict, Optional, Any, Iterator, List, Tuple
+from typing import Dict, Optional, Any, Iterator, List, Tuple
 
 import numpy as np
 from qiskit.result import Result, Counts
@@ -28,11 +28,7 @@ from qiskit.ignis.experiments.calibration.workflow import AnalysisWorkFlow
 class Calibration1DAnalysis(Analysis):
     """
     Calibration1DAnalysis analyzes experiments in which one parameter
-    is scanned. The values of this parameter form the x_values.
-    The experiment may have several series which are interpreted as
-    different curves. The x_values metadata for each circuit should
-    therefore be a dict with one entry and have the form
-    {parameter_name: parameter_value}.
+    is scanned.
     """
 
     def __init__(self,

--- a/qiskit/ignis/experiments/calibration/analysis/cal_1d_analysis.py
+++ b/qiskit/ignis/experiments/calibration/analysis/cal_1d_analysis.py
@@ -16,7 +16,6 @@ from collections import defaultdict
 from typing import Union, Dict, Optional, Any, Iterator, List, Tuple
 
 import numpy as np
-from qiskit.circuit import Parameter
 from qiskit.result import Result, Counts
 from scipy import optimize
 
@@ -33,7 +32,8 @@ class Calibration1DAnalysis(Analysis):
                  name: Optional[str] = None,
                  data: Optional[Any] = None,
                  metadata: Optional[Dict[str, Any]] = None,
-                 exp_id: Optional[str] = None):
+                 exp_id: Optional[str] = None,
+                 workflow: Optional[AnalysisWorkFlow] = None):
         """Initialize calibration experiment analysis
 
         Args:
@@ -41,16 +41,17 @@ class Calibration1DAnalysis(Analysis):
             data: Result data to initialize with.
             metadata: Metadata to initialize with.
             exp_id: Experiment id string.
+            workflow: the steps to process the data with.
 
         Additional Information:
             Pulse job doesn't return marginalized result.
             Result memory slot is marginalized with qubits specified in metadata.
 
-            User don't need to take care of data format.
+            Users do not need to take care of data format.
             Data is automatically processed based on the give workflow.
         """
         # Workflow for measurement data processing
-        self._workflow = None
+        self._workflow = workflow
         self._parameter = None
         self._series = {}
         self._x_values = None

--- a/qiskit/ignis/experiments/calibration/analysis/cal_1d_analysis.py
+++ b/qiskit/ignis/experiments/calibration/analysis/cal_1d_analysis.py
@@ -26,7 +26,14 @@ from qiskit.ignis.experiments.calibration.workflow import AnalysisWorkFlow
 
 
 class Calibration1DAnalysis(Analysis):
-    """Calibration experiment analysis."""
+    """
+    Calibration1DAnalysis analyzes experiments in which one parameter
+    is scanned. The values of this parameter form the x_values.
+    The experiment may have several series which are interpreted as
+    different curves. The x_values metadata for each circuit should
+    therefore be a dict with one entry and have the form
+    {parameter_name: parameter_value}.
+    """
 
     def __init__(self,
                  name: Optional[str] = None,

--- a/qiskit/ignis/experiments/calibration/analysis/peak.py
+++ b/qiskit/ignis/experiments/calibration/analysis/peak.py
@@ -15,7 +15,7 @@ import numpy as np
 from typing import Iterator, Tuple, List
 
 
-from qiskit.ignis.experiments.calibration import Calibration1DAnalysis
+from qiskit.ignis.experiments.calibration.analysis.cal_1d_analysis import Calibration1DAnalysis
 
 
 class GaussianFit(Calibration1DAnalysis):

--- a/qiskit/ignis/experiments/calibration/analysis/trigonometric.py
+++ b/qiskit/ignis/experiments/calibration/analysis/trigonometric.py
@@ -13,9 +13,9 @@
 import numpy as np
 
 from scipy import signal
-from typing import Iterator, Tuple, List, Dict
+from typing import Iterator, Tuple, List
 
-from qiskit.ignis.experiments.calibration import Calibration1DAnalysis
+from qiskit.ignis.experiments.calibration.analysis.cal_1d_analysis import Calibration1DAnalysis
 
 
 def _freq_guess(xvals: np.ndarray, yvals: np.ndarray):

--- a/qiskit/ignis/experiments/calibration/cal_base_experiment.py
+++ b/qiskit/ignis/experiments/calibration/cal_base_experiment.py
@@ -24,12 +24,6 @@ from qiskit.ignis.experiments.base import Experiment
 class BaseCalibrationExperiment(Experiment):
     """
     Class for a calibration experiments.
-    Typically we calibrate pulse parameters. These pulse parameters are
-    stored in a table with their values. The calibration experiments
-    rely on generators to produce the circuits and analyze the data
-    with an Analysis class, typically responsible for extracting pulse
-    parameters from the data. The analysis defines the steps by which
-    the data is processed.
     """
 
     def schedules(self, backend: BaseBackend) -> List[pulse.Schedule]:

--- a/qiskit/ignis/experiments/calibration/cal_base_experiment.py
+++ b/qiskit/ignis/experiments/calibration/cal_base_experiment.py
@@ -13,32 +13,24 @@
 """Qiskit Ignis calibration module."""
 
 import uuid
-from typing import List, Optional
+from typing import List
 
 from qiskit import transpile, schedule, assemble, pulse
 from qiskit.providers import BaseBackend, BaseJob
 
 from qiskit.ignis.experiments.base import Experiment
-from qiskit.ignis.experiments.calibration import Calibration1DAnalysis
-from qiskit.ignis.experiments.calibration.exceptions import CalExpError
-from qiskit.ignis.experiments.calibration.workflow import AnalysisWorkFlow
-from qiskit.ignis.experiments.base import Generator, Analysis
 
 
 class BaseCalibrationExperiment(Experiment):
-    """An experiment class for a calibration experiment."""
-    def __init__(self,
-                 generator: Optional[Generator] = None,
-                 analysis: Optional[Analysis] = None,
-                 job: Optional[BaseJob] = None,
-                 workflow: Optional[AnalysisWorkFlow] = None):
-        """Initialize an experiment."""
-        # data processing chain
-        self._workflow = workflow
-
-        super().__init__(generator=generator,
-                         analysis=analysis,
-                         job=job)
+    """
+    Class for a calibration experiments.
+    Typically we calibrate pulse parameters. These pulse parameters are
+    stored in a table with their values. The calibration experiments
+    rely on generators to produce the circuits and analyze the data
+    with an Analysis class, typically responsible for extracting pulse
+    parameters from the data. The analysis defines the steps by which
+    the data is processed.
+    """
 
     def schedules(self, backend: BaseBackend) -> List[pulse.Schedule]:
         """Return pulse schedules to submit."""
@@ -81,25 +73,19 @@ class BaseCalibrationExperiment(Experiment):
             meta['exp_id'] = exp_id
             meta['qubits'] = self.generator.qubits
 
-        # store shots information for post processing
-        self._workflow.shots = kwargs.get('shots', 1024)
+        # The analysis data processing requires certain predefined data types.
+        self.analysis.workflow.shots = kwargs.get('shots', 1024)
+        shots = self.analysis.workflow.shots
+        meas_level = self.analysis.workflow.meas_level()
+        meas_return = self.analysis.workflow.meas_return()
 
-        # Assemble qobj and submit to backend
+        # Assemble and submit to backend
         qobj = assemble(schedules,
                         backend=backend,
                         qobj_header={'metadata': metadata},
-                        meas_level=self._workflow.meas_level(),
-                        meas_return=self._workflow.meas_return(),
-                        shots=self._workflow.shots,
+                        meas_level=meas_level,
+                        meas_return=meas_return,
+                        shots=shots,
                         **kwargs)
         self._job = backend.run(qobj)
         return self
-
-    def run_analysis(self, **params):
-        """Analyze the stored data.
-
-        Returns:
-            any: the output of the analysis,
-        """
-        self.analysis.workflow = self._workflow
-        super().run_analysis(**params)

--- a/qiskit/ignis/experiments/calibration/cal_base_generator.py
+++ b/qiskit/ignis/experiments/calibration/cal_base_generator.py
@@ -48,9 +48,13 @@ class Base1QCalibrationGenerator(Generator):
         self._scanned_values = values_to_scan
         self._ref_frequency = ref_frequency
 
-    def _template_qcs(self) -> List[QuantumCircuit]:
-        """Create the template quantum circuit(s).
-        """
+    @property
+    def parameters(self):
+        """Returns the list of parameters that the generator uses."""
+        return self._parameters
+
+    def template_qcs(self) -> List[QuantumCircuit]:
+        """Create the template quantum circuit(s)."""
         raise NotImplementedError
 
     def circuits(self) -> List[QuantumCircuit]:
@@ -61,7 +65,7 @@ class Base1QCalibrationGenerator(Generator):
         meta data to the circuits.
         """
         cal_circs = []
-        for template_qc in self._template_qcs():
+        for template_qc in self.template_qcs():
             parameter = list(template_qc.parameters)[0]
             for val in self._scanned_values:
                 cal_circs.append(template_qc.assign_parameters({parameter: val}))
@@ -73,7 +77,7 @@ class Base1QCalibrationGenerator(Generator):
         Creates the metadata for the experiment.
         """
         metadata = []
-        for template_qc in self._template_qcs():
+        for template_qc in self.template_qcs():
             parameter = list(template_qc.parameters)[0]
             for val in self._scanned_values:
                 x_values = {

--- a/qiskit/ignis/experiments/calibration/cal_table.py
+++ b/qiskit/ignis/experiments/calibration/cal_table.py
@@ -18,6 +18,7 @@ import numpy as np
 import pandas as pd
 
 from qiskit import pulse, circuit
+from qiskit.circuit import ParameterExpression
 from qiskit.ignis.experiments.calibration import types
 
 
@@ -143,7 +144,10 @@ class PulseTable:
         # convert (amp, phase) pair into complex value
         if use_complex_amplitude:
             if 'amp' in format_dict and 'phase' in format_dict:
-                format_dict['amp'] *= np.exp(1j * format_dict.pop('phase'))
+                if not isinstance(format_dict['amp'], ParameterExpression):
+                    format_dict['amp'] *= np.exp(1j * format_dict.pop('phase'))
+                else:
+                    format_dict.pop('phase')
 
         # convert duration into integer
         if 'duration' in format_dict and isinstance(format_dict['duration'], float):

--- a/qiskit/ignis/experiments/calibration/cal_table.py
+++ b/qiskit/ignis/experiments/calibration/cal_table.py
@@ -144,10 +144,7 @@ class PulseTable:
         # convert (amp, phase) pair into complex value
         if use_complex_amplitude:
             if 'amp' in format_dict and 'phase' in format_dict:
-                if not isinstance(format_dict['amp'], ParameterExpression):
-                    format_dict['amp'] *= np.exp(1j * format_dict.pop('phase'))
-                else:
-                    format_dict.pop('phase')
+                format_dict['amp'] *= np.exp(1j * format_dict.pop('phase'))
 
         # convert duration into integer
         if 'duration' in format_dict and isinstance(format_dict['duration'], float):

--- a/qiskit/ignis/experiments/calibration/cal_table.py
+++ b/qiskit/ignis/experiments/calibration/cal_table.py
@@ -18,7 +18,6 @@ import numpy as np
 import pandas as pd
 
 from qiskit import pulse, circuit
-from qiskit.circuit import ParameterExpression
 from qiskit.ignis.experiments.calibration import types
 
 

--- a/qiskit/ignis/experiments/calibration/generators/single_qubit.py
+++ b/qiskit/ignis/experiments/calibration/generators/single_qubit.py
@@ -62,7 +62,7 @@ class SinglePulseGenerator(Base1QCalibrationGenerator):
         Creates the template quantum circuits.
         """
         cal_sched = self.single_pulse_schedule()
-        parameter = list(cal_sched.parameters)[0]  # TODO This fails
+        parameter = list(cal_sched.parameters)[0]
 
         template_qc = QuantumCircuit(1, 1, name='single_pulse')
         gate = Gate(parameter.name, 1, [parameter])

--- a/qiskit/ignis/experiments/calibration/generators/single_qubit.py
+++ b/qiskit/ignis/experiments/calibration/generators/single_qubit.py
@@ -25,8 +25,7 @@ from qiskit.ignis.experiments.calibration.cal_base_generator import Base1QCalibr
 class SinglePulseGenerator(Base1QCalibrationGenerator):
     """
     A generator that generates single pulses and scans a single parameter
-    of that pulse. Note that the same pulse may be applied to multiple qubits
-    to perform simultaneous calibration.
+    of that pulse.
     """
     def __init__(self,
                  name: str,
@@ -58,11 +57,12 @@ class SinglePulseGenerator(Base1QCalibrationGenerator):
                          values_to_scan=values_to_scan,
                          ref_frequency=ref_frequency)
 
-    def _template_qcs(self) -> List[QuantumCircuit]:
-        """Create the template quantum circuit.
+    def template_qcs(self) -> List[QuantumCircuit]:
+        """
+        Creates the template quantum circuits.
         """
         cal_sched = self.single_pulse_schedule()
-        parameter = list(cal_sched.parameters)[0]
+        parameter = list(cal_sched.parameters)[0]  # TODO This fails
 
         template_qc = QuantumCircuit(1, 1, name='single_pulse')
         gate = Gate(parameter.name, 1, [parameter])
@@ -122,7 +122,7 @@ class RamseyXYGenerator(Base1QCalibrationGenerator):
                          values_to_scan=delays,
                          ref_frequency=ref_frequency)
 
-    def _template_qcs(self) -> List[QuantumCircuit]:
+    def template_qcs(self) -> List[QuantumCircuit]:
         """Create the template quantum circuit.
         """
         cal_series = {'x': self.ramsey_x_schedule(), 'y': self.ramsey_y_schedule()}

--- a/qiskit/ignis/experiments/calibration/methods/basic_1q.py
+++ b/qiskit/ignis/experiments/calibration/methods/basic_1q.py
@@ -19,18 +19,19 @@ from qiskit import circuit
 
 from qiskit.ignis.experiments.calibration import (types,
                                                   generators,
-                                                  analysis,
                                                   workflow,
-                                                  cal_table,
                                                   Calibration1DAnalysis)
 from qiskit.ignis.experiments.calibration.cal_base_experiment import BaseCalibrationExperiment
+from qiskit.ignis.experiments.calibration.cal_table import PulseTable
+from qiskit.ignis.experiments.calibration.analysis.peak import GaussianFit
+from qiskit.ignis.experiments.calibration.analysis.trigonometric import CosinusoidalFit
 
 
 class RoughSpectroscopy(BaseCalibrationExperiment):
     """Performs a frequency spectroscopy by scanning the drive channel frequency."""
 
     def __init__(self,
-                 table: cal_table.PulseTable,
+                 table: PulseTable,
                  qubit: int,
                  data_processing: workflow.AnalysisWorkFlow,
                  freq_vals: np.ndarray,
@@ -38,10 +39,10 @@ class RoughSpectroscopy(BaseCalibrationExperiment):
                  job: Optional = None,
                  pulse_envelope: Optional[Callable] = None,
                  pulse_name: Optional[str] = types.SingleQubitPulses.XP.value):
-        """Create new rabi amplitude experiment.
+        """Create new spectroscopy experiment.
 
         Args:
-            table:
+            table: The table of pulse parameters.
             qubit: Qubit on which to run the calibration.
             data_processing: Steps used to process the data from the Result.
             freq_vals: Frequency values to scan in the calibration.
@@ -75,19 +76,18 @@ class RoughSpectroscopy(BaseCalibrationExperiment):
 
         # setup analysis
         if analysis_class is None:
-            analysis_class = analysis.GaussianFit(name=generator.name)
+            analysis_class = GaussianFit(name=generator.name, workflow=data_processing)
 
         super().__init__(generator=generator,
                          analysis=analysis_class,
-                         job=job,
-                         workflow=data_processing)
+                         job=job)
 
 
 class RoughAmplitudeCalibration(BaseCalibrationExperiment):
     """Performs a rough amplitude calibration by scanning the amplitude of the pulse."""
 
     def __init__(self,
-                 table: cal_table.PulseTable,
+                 table: PulseTable,
                  qubit: int,
                  data_processing: workflow.AnalysisWorkFlow,
                  amp_vals: np.ndarray,
@@ -98,12 +98,12 @@ class RoughAmplitudeCalibration(BaseCalibrationExperiment):
         """Create new rabi amplitude experiment.
 
         Args:
-            table:
+            table: The table of pulse parameters.
             qubit: Qubit on which to run the calibration.
             data_processing: Steps used to process the data from the Result.
             amp_vals: Amplitude values to scan in the calibration.
             analysis_class: Analysis class used.
-            job: Optional job id to retrive past expereiments.
+            job: Optional job id to retrieve past experiments.
             pulse_envelope: Name of the pulse function used to generate the
                 pulse schedule. If not specified, the default pulse shape of
                 :py:class:`SinglePulseGenerator` is used.
@@ -133,9 +133,8 @@ class RoughAmplitudeCalibration(BaseCalibrationExperiment):
 
         # setup analysis
         if analysis_class is None:
-            analysis_class = analysis.CosinusoidalFit(name=generator.name)
+            analysis_class = CosinusoidalFit(name=generator.name, workflow=data_processing)
 
         super().__init__(generator=generator,
                          analysis=analysis_class,
-                         job=job,
-                         workflow=data_processing)
+                         job=job)


### PR DESCRIPTION
## Summary

The purpose of this PR is to move workflow fully into analysis and improve code quality.

### Details

  - Moved workflow into Analysis. This simplified BaseCalibrationExperiment quite a bit.
  - Improved docstrings.
  - Made template circuits non-private as the user may which to see them.
  - Refactored imports a bit.
  - Parameters of Generator are now a property so that we can see them.
  - Added test in PulseTable to not do anything to 'amp' when it is a ParameterExpression.

