### PR TITLE
First draft of the class to manage calibrations as circuits

### DIFF
--- a/qiskit/ignis/experiments/calibration/instruction_data/__init__.py
+++ b/qiskit/ignis/experiments/calibration/instruction_data/__init__.py
@@ -13,3 +13,4 @@
 """Local relational database for instruction data."""
 
 from qiskit.ignis.experiments.calibration.instruction_data.interface import InstructionSet
+from qiskit.ignis.experiments.calibration.instruction_data.gate_and_schedules_definition import InstructionsDefinition

--- a/qiskit/ignis/experiments/calibration/instruction_data/gate_and_schedules_definition.py
+++ b/qiskit/ignis/experiments/calibration/instruction_data/gate_and_schedules_definition.py
@@ -69,7 +69,7 @@ class InstructionsDefinition:
         return circ
 
     def get_schedule(self, name: str, qubits: Tuple,
-                     free_parameter_names: List[str] = None) -> Schedule:
+                     free_parameter_names: Optional[List[str]] = None) -> Schedule:
         """
         Retrieves a schedule from the instructions dictionary.
 

--- a/qiskit/ignis/experiments/calibration/instruction_data/gate_and_schedules_definition.py
+++ b/qiskit/ignis/experiments/calibration/instruction_data/gate_and_schedules_definition.py
@@ -34,7 +34,7 @@ class InstructionsDefinition:
         Returns:
             A QuantumCircuit with parameters in it.
         """
-        return self._instructions[(name, qubits)]
+        return self._instructions.get((name, qubits), None)
 
     def get_instruction(self, name: str, qubits: Iterable,
                         free_parameters: List = None) -> QuantumCircuit:
@@ -112,12 +112,12 @@ class InstructionsDefinition:
 
         return params
 
-    def add_composite_instruction(self, name: str, instructions: List[List[Tuple[str, set]]]):
+    def add_composite_instruction(self, inst_name: str, instructions: List[List[Tuple[str, set]]]):
         """
         Creates a new instruction from the given list of instructions.
 
         Args:
-            name: Name of the composite instruction to add
+            inst_name: Name of the composite instruction to add
             instructions: The instructions to add to the circuit. Instructions are grouped
                 by barriers to enforce relative timing between the instructions. Each instruction
                 is specified by its name and the qubit it applies to.
@@ -127,14 +127,14 @@ class InstructionsDefinition:
             for inst_config in inst_list:
                 all_qubits |= set(inst_config[1])
 
-        circ = QuantumCircuit(max(all_qubits))
+        circ = QuantumCircuit(max(all_qubits)+1)
         for inst_list in instructions:
             for inst_config in inst_list:
                 name = inst_config[0]
                 qubits = inst_config[1]
                 qc = self.get_instruction_template(name, qubits)
-                circ.compose(qc, qubits=qubits)
+                circ.compose(qc, qubits=qubits, inplace=True)
 
             circ.barrier()
 
-        self._instructions[(name, all_qubits)] = circ
+        self._instructions[(inst_name, tuple(all_qubits))] = circ

--- a/qiskit/ignis/experiments/calibration/instruction_data/gate_and_schedules_definition.py
+++ b/qiskit/ignis/experiments/calibration/instruction_data/gate_and_schedules_definition.py
@@ -1,0 +1,140 @@
+from typing import Dict, Callable, List, Tuple, Iterable
+
+from qiskit import QuantumCircuit
+from qiskit.circuit import ParameterExpression, Gate, Parameter
+from qiskit.pulse import Play, Schedule, ControlChannel, ParametricPulse
+from qiskit.pulse.channels import PulseChannel
+
+
+class InstructionsDefinition:
+    """
+    Class to track calibrated instructions for the calibration module of Ignis.
+
+    The class allows users to define single-pulse schedules as quantum circuits and
+    then leverage the quantum circuit compose operation to compose more complex
+    circuits from basic circuits.
+    """
+
+    def __init__(self):
+
+        # Dict to store the instructions we are calibrating
+        self._instructions = {}
+
+    @property
+    def instructions(self) -> Dict[Tuple[str, Iterable], QuantumCircuit]:
+        """Return the instructions as a dict."""
+        return self._instructions
+
+    def get_instruction_template(self, name: str, qubits: Iterable) -> QuantumCircuit:
+        """
+        Args:
+            name: Name of the instruction to get.
+            qubits: Set of qubits to which the instruction applies.
+
+        Returns:
+            A QuantumCircuit with parameters in it.
+        """
+        return self._instructions[(name, qubits)]
+
+    def get_instruction(self, name: str, qubits: Iterable,
+                        free_parameters: List = None) -> QuantumCircuit:
+        """
+        Returns the QuantumCircuit of the instruction where all parameters aside for those
+        explicitly specified are bound to their calibration.
+
+        Args:
+            name: name of the instruction to retrive
+            qubits: qubits to which the instruction applies.
+            free_parameters: Parameters that should be left unbound. If None is specified then
+                all parameters will be bound to their calibrated values.
+        """
+        # TODO Get the parameters
+
+        # TODO Get their values
+
+        # TODO return circ with parameters assigned
+        raise NotImplemented
+
+    def create_basic_instruction(self, name: str, duration: int, pulse_envelope: ParametricPulse,
+                                 channel: PulseChannel, params = None):
+        """
+        Creates a basic instruction in the dictionary.
+
+        Args:
+            name:
+            duration: The duration of the pulse schedule.
+            pulse_envelope: The callable pulse envelope. Its parameters are given by
+                **params after duration is added to it.
+            channel: The channel to which we apply the basic instruction.
+        """
+        # Avoids having the user manage the parameters.
+        if not params:
+            params = self._basic_inst_parameters(name, channel, pulse_envelope)
+
+        gate = Gate(name=name, num_qubits=1, params=[_ for _ in params.values()])
+
+        if duration:
+            params['duration'] = duration
+
+        schedule = Schedule(name=name)
+        schedule = schedule.insert(0, Play(pulse_envelope(**params), channel))
+
+        if isinstance(channel, ControlChannel):
+            # TODO Need a mapping from ControlChannel to qubits
+            # TODO This works for CR, would it work for TC?
+            raise NotImplemented
+        else:
+            qubit = int(channel.name.replace('d', '').replace('m', ''))
+
+        circ = QuantumCircuit(1)
+        circ.append(gate, [0])
+        circ.add_calibration(gate, [qubit], schedule)
+
+        self._instructions[(name, (qubit))] = circ
+
+    def _basic_inst_parameters(self, name: str, channel: PulseChannel,
+                               pulse_envelope: ParametricPulse) -> Dict[str, ParameterExpression]:
+        """
+        This functions avoids the user to have to manage parameters and their name.
+
+        TODO Is there a better way of doing this?
+        """
+        params = {}
+        if pulse_envelope.__name__ in ['Drag', 'Gaussian', 'GaussianSquare']:
+            params['amp'] = Parameter(name + '.' + channel.name + '.amp')
+            params['sigma'] = Parameter(name + '.' + channel.name + '.sigma')
+
+        if pulse_envelope.__name__ == 'Drag':
+            params['beta'] = Parameter(name + '.' + channel.name + '.beta')
+
+        if pulse_envelope.__name__ == 'GaussianSquare':
+            params['width'] = Parameter(name + '.' + channel.name + '.width')
+
+        return params
+
+    def add_composite_instruction(self, name: str, instructions: List[List[Tuple[str, set]]]):
+        """
+        Creates a new instruction from the given list of instructions.
+
+        Args:
+            name: Name of the composite instruction to add
+            instructions: The instructions to add to the circuit. Instructions are grouped
+                by barriers to enforce relative timing between the instructions. Each instruction
+                is specified by its name and the qubit it applies to.
+        """
+        all_qubits = set()
+        for inst_list in instructions:
+            for inst_config in inst_list:
+                all_qubits |= set(inst_config[1])
+
+        circ = QuantumCircuit(max(all_qubits))
+        for inst_list in instructions:
+            for inst_config in inst_list:
+                name = inst_config[0]
+                qubits = inst_config[1]
+                qc, qubits = self.get_instruction_template(name, qubits)
+                circ.compose(qc, qubits=qubits)
+
+            circ.barrier()
+
+        self._instructions[(name, all_qubits)] = circ

--- a/qiskit/ignis/experiments/calibration/instruction_data/gate_and_schedules_definition.py
+++ b/qiskit/ignis/experiments/calibration/instruction_data/gate_and_schedules_definition.py
@@ -76,6 +76,11 @@ class InstructionsDefinition:
         """Return the instructions as a dict."""
         return self._instructions
 
+    @property
+    def pulse_parameter_table(self) -> PulseTable:
+        """Returns the table of pulse parameters."""
+        return self._pulse_table
+
     def get_calibration(self):
         """Returns the calibrations."""
         return self._pulse_table.filter_data()

--- a/qiskit/ignis/experiments/calibration/instruction_data/gate_and_schedules_definition.py
+++ b/qiskit/ignis/experiments/calibration/instruction_data/gate_and_schedules_definition.py
@@ -118,7 +118,7 @@ class InstructionsDefinition:
         schedule = self._instructions[(name, qubits)]
 
         if not isinstance(schedule, Schedule):
-            schedule = self.get_composite_instruction(schedule)
+            schedule = self._get_composite_instruction(schedule)
 
         schedule = copy.deepcopy(schedule)
 
@@ -240,7 +240,7 @@ class InstructionsDefinition:
 
         self._instructions[(name, tuple(qubits))] = instructions
 
-    def get_composite_instruction(self, instructions: List[List[Tuple[str, Tuple]]]) -> Schedule:
+    def _get_composite_instruction(self, instructions: List[List[Tuple[str, Tuple]]]) -> Schedule:
         """
         Recursive function to obtain a schedule.
         """
@@ -254,7 +254,7 @@ class InstructionsDefinition:
                     inst = self._instructions[(name, qubits)]
 
                     if not isinstance(inst, Schedule):
-                        sched = self.get_composite_instruction(inst)
+                        sched = self._get_composite_instruction(inst)
                     else:
                         sched = inst
 

--- a/qiskit/ignis/experiments/calibration/instruction_data/gate_and_schedules_definition.py
+++ b/qiskit/ignis/experiments/calibration/instruction_data/gate_and_schedules_definition.py
@@ -90,7 +90,7 @@ class InstructionsDefinition:
         circ.append(gate, [0])
         circ.add_calibration(gate, [qubit], schedule)
 
-        self._instructions[(name, (qubit))] = circ
+        self._instructions[(name, (qubit, ))] = circ
 
     def _basic_inst_parameters(self, name: str, channel: PulseChannel,
                                pulse_envelope: ParametricPulse) -> Dict[str, ParameterExpression]:
@@ -132,7 +132,7 @@ class InstructionsDefinition:
             for inst_config in inst_list:
                 name = inst_config[0]
                 qubits = inst_config[1]
-                qc, qubits = self.get_instruction_template(name, qubits)
+                qc = self.get_instruction_template(name, qubits)
                 circ.compose(qc, qubits=qubits)
 
             circ.barrier()

--- a/qiskit/ignis/experiments/calibration/instruction_data/gate_and_schedules_definition.py
+++ b/qiskit/ignis/experiments/calibration/instruction_data/gate_and_schedules_definition.py
@@ -168,10 +168,15 @@ class InstructionsDefinition:
 
         self._pulse_table.set_parameter(qubits, ch, inst_name, pulse_type, stretch_factor, name, value)
 
-    def create_z_instruction(self, qubit: int):
+    def create_z_instruction(self, qubit: int, shift_u_channels: Optional[bool] = False):
         """
         Create a frame change instruction, i.e. a virtual Z gate.
         This instruction will apply phase changes to all channels which involve qubit.
+
+        Args:
+            qubit: The qubit upon which the Z instruction will work
+            shift_u_channels: If true the Z instruction will act on the u-channels associated
+                to the qubit.
         """
         phase = Parameter('z.d%i' % qubit + '..phase')
         schedule = Schedule(name='z')
@@ -182,7 +187,7 @@ class InstructionsDefinition:
                     channels.add(ch)
                     if ch[0] == 'd':
                         schedule.insert(0, ShiftPhase(phase, DriveChannel(int(ch[1:]))), inplace=True)
-                    if ch[0] == 'u':
+                    if ch[0] == 'u' and shift_u_channels:
                         schedule.insert(0, ShiftPhase(phase, ControlChannel(int(ch[1:]))), inplace=True)
 
         self._pulse_table.set_parameter((qubit, ), 'd%i'%qubit, 'z', '', 1.0, 'phase', np.pi)


### PR DESCRIPTION
### Summary
Users need to be able to define calibrations and compose them.

### Details and comments

At its heart, this PR implements a dict that stores quantum circuits as calibrations.

TODO

- [x] Link to pulse parameters table.
- [x] Local parameters

